### PR TITLE
Update System EID 104 parsing output to correctly reflect the cleared log name

### DIFF
--- a/DeepBlue.ps1
+++ b/DeepBlue.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
 
 A PowerShell module for hunt teaming via Windows event logs
@@ -87,7 +87,7 @@ function Main {
             Date    = $event.TimeCreated
             Log     = $logname
             EventID = $event.id
-            Message = ""
+            Message = $event.message
             Results = ""
             Command = ""
             Decoded = ""
@@ -405,7 +405,7 @@ function Main {
             ElseIf ($event.id -eq 104){
                 # The System log file was cleared.
                 $obj.Message = "System Log Clear"
-                $obj.Results = "The System log was cleared."
+                $obj.Results = $event.message
                 Write-Output $obj
             }
         } 


### PR DESCRIPTION
**_Resubmitting at the request of @joswr1ght to remove accidental whitespace edits in #21._** 

Currently, `DeepBlue.ps1` will parse all System EID 104 events as "The System log was cleared" in any output format, as shown below using the `Out-GridView` cmdlet.

![deepbluecli-old](https://user-images.githubusercontent.com/39965193/117206033-579a7b00-adc0-11eb-99a0-f51d481569fe.png)

However, System EID 104 can also relate to other log types than just System and the current hardcoded "The System log was cleared" message can be misleading. I modified `DeepBlue.ps1` to pull the `message` field from the EVTX log to a variable and utilize that for System EID 104 output instead of a hardcoded message. This adjustment is reflected below against the same log data using the `Out-GridView` cmdlet, showing that both **System** and **Application** log files were cleared, not just System.

![deepbluecli-new](https://user-images.githubusercontent.com/39965193/117206049-5b2e0200-adc0-11eb-89b8-964b44738d53.png)

This change should help investigators more easily identify which log types were cleared on the target system they are investigating.

**Please note that this proposed change only applies to the PS1 script - I have not made any attempts to utilize or adjust the Python version of this program.**