### PR TITLE
Fixed windows event log check.

### DIFF
--- a/DeepBlue.ps1
+++ b/DeepBlue.ps1
@@ -391,7 +391,7 @@ function Main {
             ElseIf ($event.id -eq 7040){
                 # The start type of the Windows Event Log service was changed from auto start to disabled.
                 $servicename=$eventXML.Event.EventData.Data[0]."#text"
-                $action = $eventXML.Event.EventData.Data[1]."#text"
+                $action = $eventXML.Event.EventData.Data[2]."#text"
                 if ($servicename -ccontains "Windows Event Log") {
                     $obj.Results = "Service name: $servicename`n"
                     $obj.Results += $text


### PR DESCRIPTION
The output of the start/stop windows event log service was not correct. 
After checking the script on the sample file: disablestop-eventlog.evtx I have noticed that the output was not correct and found out it is actually the third parameter that should be checked instead of the second.